### PR TITLE
Add SPM executable product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
@@ -7,11 +7,9 @@ let package = Package(
 		.macOS(.v10_10)
 	],
 	products: [
-		.executable(name: "trash", targets: ["trash"]),
+		.executable(name: "trash", targets: ["trash"])
 	],
 	targets: [
-		.target(
-			name: "trash"
-		)
+		.target(name: "trash")
 	]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,9 @@ let package = Package(
 	platforms: [
 		.macOS(.v10_10)
 	],
+        products: [
+                .executable(name: "trash", targets: ["trash"]),
+        ],
 	targets: [
 		.target(
 			name: "trash"

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ let package = Package(
 	platforms: [
 		.macOS(.v10_10)
 	],
-        products: [
-                .executable(name: "trash", targets: ["trash"]),
-        ],
+	products: [
+		.executable(name: "trash", targets: ["trash"]),
+	],
 	targets: [
 		.target(
 			name: "trash"

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,12 @@ Requires macOS 10.10 or later. macOS 10.13 or earlier needs to download the [Swi
 $ brew install macos-trash
 ```
 
+###### [mint](https://github.com/yonaskolb/Mint)
+
+```
+$ mint install sindresorhus/macos-trash
+```
+
 ###### Manually
 
 [Download](https://github.com/sindresorhus/macos-trash/releases/latest) the binary and put it in `/usr/local/bin`.

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Requires macOS 10.10 or later. macOS 10.13 or earlier needs to download the [Swi
 $ brew install macos-trash
 ```
 
-###### [mint](https://github.com/yonaskolb/Mint)
+###### [Mint](https://github.com/yonaskolb/Mint)
 
 ```
 $ mint install sindresorhus/macos-trash


### PR DESCRIPTION
Adding an executable product to `Package.swift` allows running via `swift run` and more importantly easy installation from source via tools like [mint](https://github.com/yonaskolb/Mint) with just 
```mint install sindresorhus/macos-trash```

Some people might prefer installation from source rather than downloading a binary, especially while homebrew does not yet support Silicon :)