### PR TITLE
add support for verbose flags

### DIFF
--- a/Sources/trash/main.swift
+++ b/Sources/trash/main.swift
@@ -2,12 +2,14 @@ import Foundation
 
 let VERSION = "1.1.1"
 
-func trash(paths: [String]) {
+func trash(paths: [String], verbose: Bool) {
 	// Ensures the user's trash is used.
 	CLI.revertSudo()
 
-	for path in CLI.arguments {
+	for path in paths {
 		let url = URL(fileURLWithPath: path)
+
+		if (verbose) { print(path) }
 
 		CLI.tryOrExit {
 			try FileManager.default.trashItem(at: url, resultingItemURL: nil)
@@ -22,9 +24,19 @@ case "--help":
 case "--version":
 	print(VERSION)
 	exit(0)
+case "-v":
+	trash(paths: CLI.argumentsWithoutFlag, verbose: true)
+case "-rv":
+	trash(paths: CLI.argumentsWithoutFlag, verbose: true)
+case "-fv":
+	trash(paths: CLI.argumentsWithoutFlag, verbose: true)
+case "-rfv":
+	trash(paths: CLI.argumentsWithoutFlag, verbose: true)
+case "-frv":
+	trash(paths: CLI.argumentsWithoutFlag, verbose: true)
 case .none:
 	print("Specify one or more paths", to: .standardError)
 	exit(1)
 default:
-	trash(paths: CLI.arguments)
+	trash(paths: CLI.arguments, verbose: false)
 }

--- a/Sources/trash/main.swift
+++ b/Sources/trash/main.swift
@@ -9,7 +9,9 @@ func trash(paths: [String], verbose: Bool) {
 	for path in paths {
 		let url = URL(fileURLWithPath: path)
 
-		if (verbose) { print(path) }
+		if (verbose) {
+			print(path)
+		}
 
 		CLI.tryOrExit {
 			try FileManager.default.trashItem(at: url, resultingItemURL: nil)

--- a/Sources/trash/util.swift
+++ b/Sources/trash/util.swift
@@ -12,6 +12,7 @@ struct CLI {
 	static var standardError = FileHandle.standardError
 
 	static let arguments = Array(CommandLine.arguments.dropFirst(1))
+	static let argumentsWithoutFlag = Array(CommandLine.arguments.dropFirst(2))
 
 	/// Execute code and print to `stderr` and exit with code 1 if it throws.
 	static func tryOrExit(_ throwingFunc: () throws -> Void) {


### PR DESCRIPTION
This PR attempts to add support for verbose flags.

For example, suppose I've aliased `rm` to `trash` and I run the command `rm -rfv <directory>`. As a user, my expectation would be that the deleted filenames would be printed to the console.

I'm not a Swift developer by trade, so I'd be interested in learning more if anyone knows of a better way to check for the `-v` flag without having to use multiple switch cases, perhaps with a regex that checks if the string begins with a dash and contains a "v".

I would also be interested in knowing if there's a better way to implement this in general. For example, in this PR I'm printing the filename to the console before it actually tries to delete the file, which is obviously not ideal. It doesn't look like there are any other options that can be passed to `FileManager.default.trashItem()`.

---

FIxes #13