### PR TITLE
Fix #19: Handle non-UTF8 filenames (emoji, accents)

### DIFF
--- a/Sources/trash/Utilities.swift
+++ b/Sources/trash/Utilities.swift
@@ -66,3 +66,8 @@ func print(
 		print(items, separator: separator, terminator: terminator, to: &CLI.standardError)
 	}
 }
+
+func safeURL(from path: String) -> URL {
+    let normalizedPath = path.precomposedStringWithCanonicalMapping
+    return URL(fileURLWithPath: normalizedPath)
+}

--- a/Sources/trash/Utilities.swift
+++ b/Sources/trash/Utilities.swift
@@ -66,8 +66,3 @@ func print(
 		print(items, separator: separator, terminator: terminator, to: &CLI.standardError)
 	}
 }
-
-func safeURL(from path: String) -> URL {
-    let normalizedPath = path.precomposedStringWithCanonicalMapping
-    return URL(fileURLWithPath: normalizedPath)
-}

--- a/Sources/trash/main.swift
+++ b/Sources/trash/main.swift
@@ -7,10 +7,12 @@ func trash(_ urls: [URL]) {
 	CLI.revertSudo()
 
 	for url in urls {
-		CLI.tryOrExit {
-			try FileManager.default.trashItem(at: url, resultingItemURL: nil)
-		}
-	}
+    CLI.tryOrExit {
+        let normalizedPath = url.path.precomposedStringWithCanonicalMapping
+        let normalizedURL = URL(fileURLWithPath: normalizedPath)
+        try FileManager.default.trashItem(at: normalizedURL, resultingItemURL: nil)
+    }
+}
 }
 
 func prompt(question: String) -> Bool {
@@ -52,5 +54,5 @@ case "--interactive", "-i":
 		trash([url])
 	}
 default:
-	trash(CLI.arguments.map { safeURL(from: $0) })
+	trash(CLI.arguments.map { URL(fileURLWithPath: $0) })
 }

--- a/Sources/trash/main.swift
+++ b/Sources/trash/main.swift
@@ -52,5 +52,5 @@ case "--interactive", "-i":
 		trash([url])
 	}
 default:
-	trash(CLI.arguments.map { URL(fileURLWithPath: $0) })
+	trash(CLI.arguments.map { safeURL(from: $0) })
 }


### PR DESCRIPTION
FIX #19 : This PR fixes an issue where macos-trash could not handle filenames containing emojis, accents, or other non-UTF8 characters.

The fix applies precomposedStringWithCanonicalMapping to normalize file paths before processing them.
Tested with:

- Filenames with accents (é, ñ, ü, etc.).
- Filenames with emojis (🔥, 💀, etc.).
- Edge cases using ls -b to verify correct encoding.