### PR TITLE
Support safe invocation by using `--` as the first argument.

### DIFF
--- a/Sources/trash/main.swift
+++ b/Sources/trash/main.swift
@@ -51,6 +51,8 @@ case "--interactive", "-i":
 
 		trash([url])
 	}
+case "--":
+	trash(CLI.arguments.dropFirst().map { URL(fileURLWithPath: $0) })
 default:
 	trash(CLI.arguments.map { URL(fileURLWithPath: $0) })
 }


### PR DESCRIPTION
This prevents any provided paths from being parsed as flags.

Closes: https://github.com/sindresorhus/macos-trash/issues/29