### PR TITLE
fix trash command avaible in macos version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 *Requires macOS 10.13 or later.*
 
-Since macOS 14, there is now a built-in `trash` command. The benefit of the binary here is that it has a `--interactive` flag.
+Since macOS 15, there is now a built-in `trash` command. The benefit of the binary here is that it has a `--interactive` flag.
 
 ## Install
 


### PR DESCRIPTION
Checked on my MacOS 14, no build in `trash` command available.
See https://apple.stackexchange.com/questions/50844/how-to-move-files-to-trash-from-command-line/476506#476506