### PR TITLE
Add `--empty` flag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,12 @@ let package = Package(
 			dependencies: [
 				"DSStore"
 			]
+		),
+		.testTarget(
+			name: "trashTests",
+			dependencies: [
+				"trash"
+			]
 		)
 	],
 	swiftLanguageModes: [.v5]

--- a/Sources/trash/ArgumentParsing.swift
+++ b/Sources/trash/ArgumentParsing.swift
@@ -1,0 +1,49 @@
+enum CLIAction: Equatable {
+	case missingArguments
+	case help
+	case version
+	case empty
+	case interactive
+	case trash
+}
+
+func cliAction(for arguments: [String]) -> CLIAction {
+	guard !arguments.isEmpty else {
+		return .missingArguments
+	}
+
+	let leadingOptions = arguments.prefix { $0 != "--" && $0.hasPrefix("-") }
+
+	if leadingOptions.contains(where: { ["--help", "-h"].contains($0) }) {
+		return .help
+	}
+
+	if leadingOptions.contains(where: { ["--version", "-v"].contains($0) }) {
+		return .version
+	}
+
+	if leadingOptions.contains("--empty") {
+		return .empty
+	}
+
+	if leadingOptions.contains(where: { ["--interactive", "-i"].contains($0) }) {
+		return .interactive
+	}
+
+	return .trash
+}
+
+// Extract paths from arguments, filtering out flags for `rm` compatibility.
+// Removes leading `--` if present, keeps subsequent `--` as literal paths.
+func extractPaths(from arguments: some Collection<String>) -> [String] {
+	let trimmed = arguments.first == "--" ? Array(arguments.dropFirst()) : Array(arguments)
+	return trimmed.filter { !$0.hasPrefix("-") || $0 == "--" }
+}
+
+func extractInteractivePaths(from arguments: [String]) -> [String] {
+	guard let interactiveIndex = arguments.firstIndex(where: { ["--interactive", "-i"].contains($0) }) else {
+		return extractPaths(from: arguments)
+	}
+
+	return extractPaths(from: arguments[arguments.index(after: interactiveIndex)...])
+}

--- a/Sources/trash/Utilities.swift
+++ b/Sources/trash/Utilities.swift
@@ -1,6 +1,24 @@
 import Foundation
 import SystemConfiguration
 
+private struct AppleScriptExecutionError: LocalizedError {
+	let errorDescription: String?
+}
+
+func runAppleScript(_ source: String) throws {
+	guard let appleScript = NSAppleScript(source: source) else {
+		throw AppleScriptExecutionError(errorDescription: "Failed to initialize AppleScript.")
+	}
+
+	var errorInfo: NSDictionary?
+	_ = appleScript.executeAndReturnError(&errorInfo)
+
+	if let errorInfo {
+		let message = errorInfo[NSAppleScript.errorMessage] as? String
+		throw AppleScriptExecutionError(errorDescription: message ?? "Failed to execute AppleScript.")
+	}
+}
+
 extension FileHandle: @retroactive TextOutputStream {
 	public func write(_ string: String) {
 		write(string.data(using: .utf8)!)

--- a/Sources/trash/main.swift
+++ b/Sources/trash/main.swift
@@ -59,6 +59,18 @@ func trash(_ urls: [URL]) {
 	}
 }
 
+func emptyTrash() throws {
+	CLI.revertSudo()
+
+	try runAppleScript("""
+	tell application "Finder"
+		if (count items of trash) > 0 then
+			empty trash
+		end if
+	end tell
+	""")
+}
+
 /// FileManager.trashItem has a macOS bug where only the first file gets Put Back metadata.
 /// This ensures all trashed files have ptbN/ptbL records in .DS_Store.
 func writeMissingPutBackRecords(for trashedFiles: [TrashedFile]) {
@@ -123,30 +135,24 @@ func prompt(question: String) -> Bool {
 	return ["y", "yes"].contains(input.lowercased())
 }
 
-guard let argument = CLI.arguments.first else {
+switch cliAction(for: CLI.arguments) {
+case .missingArguments:
 	print("Specify one or more paths", to: .standardError)
 	exit(1)
-}
-
-// Extract paths from arguments, filtering out flags for `rm` compatibility.
-// Removes leading `--` if present, keeps subsequent `--` as literal paths.
-func extractPaths(from arguments: some Collection<String>) -> [String] {
-	let trimmed = arguments.first == "--" ? Array(arguments.dropFirst()) : Array(arguments)
-	return trimmed.filter { !$0.hasPrefix("-") || $0 == "--" }
-}
-
-switch argument {
-case "--help", "-h":
-	print("Usage: trash [--help | -h] [--version | -v] [--interactive | -i] <path> […]")
+case .help:
+	print("Usage: trash [--help | -h] [--version | -v] [--interactive | -i] [--empty] <path> […]")
 	exit(0)
-case "--version", "-v":
+case .version:
 	print(VERSION)
-	exit(0)
-case "--interactive", "-i":
+case .empty:
+	CLI.tryOrExit {
+		try emptyTrash()
+	}
+case .interactive:
 	var trashedFiles = [TrashedFile]()
 	var didFail = false
 
-	for url in extractPaths(from: CLI.arguments.dropFirst()).map({ URL(filePath: $0) }) {
+	for url in extractInteractivePaths(from: CLI.arguments).map({ URL(filePath: $0) }) {
 		guard FileManager.default.fileExists(atPath: url.path) else {
 			print("The file “\(url.relativePath)” doesn't exist.")
 			continue
@@ -163,7 +169,7 @@ case "--interactive", "-i":
 
 	writeMissingPutBackRecords(for: trashedFiles)
 	exit(didFail ? 1 : 0)
-default:
+case .trash:
 	let paths = extractPaths(from: CLI.arguments)
 	guard !paths.isEmpty else {
 		exit(0)

--- a/Tests/trashTests/ArgumentParsingTests.swift
+++ b/Tests/trashTests/ArgumentParsingTests.swift
@@ -1,0 +1,56 @@
+import Testing
+@testable import trash
+
+@Test(arguments: [
+	["--interactive", "--empty"],
+	["--empty", "--interactive"],
+	["-i", "--empty"],
+	["--empty", "-i"]
+])
+func emptyTrashTakesPrecedenceOverInteractive(arguments: [String]) {
+	#expect(cliAction(for: arguments) == .empty)
+}
+
+@Test(arguments: [
+	(["--empty", "--help"], CLIAction.help),
+	(["--help", "--empty"], CLIAction.help),
+	(["--empty", "-h"], CLIAction.help),
+	(["--empty", "--version"], CLIAction.version),
+	(["-v", "--empty"], CLIAction.version),
+	(["--version", "--help", "--empty"], CLIAction.help)
+])
+func informationalActionsTakePrecedenceOverEmpty(arguments: [String], expectedAction: CLIAction) {
+	#expect(cliAction(for: arguments) == expectedAction)
+}
+
+@Test(arguments: [
+	([], CLIAction.missingArguments),
+	(["file"], CLIAction.trash),
+	(["--interactive", "file"], CLIAction.interactive),
+	(["-rf", "--interactive", "file"], CLIAction.interactive),
+	(["-rf", "--empty"], CLIAction.empty),
+	(["file", "--empty"], CLIAction.trash),
+	(["--", "--empty"], CLIAction.trash)
+])
+func selectsActionFromLeadingOptions(arguments: [String], expectedAction: CLIAction) {
+	#expect(cliAction(for: arguments) == expectedAction)
+}
+
+@Test(arguments: [
+	(["-rf", "--interactive", "file"], ["file"]),
+	(["--", "file"], ["file"]),
+	(["file", "--empty"], ["file"])
+])
+func extractsPathsWhileIgnoringOptions(arguments: [String], expectedPaths: [String]) {
+	#expect(extractPaths(from: arguments) == expectedPaths)
+}
+
+@Test(arguments: [
+	(["--interactive", "file"], ["file"]),
+	(["-rf", "--interactive", "file"], ["file"]),
+	(["--interactive", "--", "file"], ["file"]),
+	(["-rf", "-i", "--", "file"], ["file"])
+])
+func extractsInteractivePathsAfterActionFlag(arguments: [String], expectedPaths: [String]) {
+	#expect(extractInteractivePaths(from: arguments) == expectedPaths)
+}

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ mint install sindresorhus/macos-trash
 ## Usage
 
 ```sh
-trash [--help | -h] [--version | -v] [--interactive | -i] <path> […]
+trash [--help | -h] [--version | -v] [--interactive | -i] [--empty] <path> […]
 ```
 
 ## Tips


### PR DESCRIPTION
Adds the `--empty` flag discussed in #28.

It uses Finder through `NSAppleScript`, matching the approach suggested in the issue. The command does not prompt or respect `--interactive`, and AppleScript failures are reported through the existing CLI error path.

Fixes #28

## Verification

- `swift build --disable-sandbox`
- Valid and invalid AppleScript helper checks
- Help, version, and existing CLI regression checks
- Universal `x86_64`/`arm64` release build